### PR TITLE
{main,extractor,go.mod}: adds and wires extractor initial implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+coverage.html
+coverage.out

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -1,0 +1,1 @@
+go clean -testcache && go test -cover -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o coverage.html; sed -i'' -e's/black/whitesmoke/g' coverage.html && open coverage.html

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-GITHUB_AUTH_TOKEN=$GITHUB_AUTH_TOKEN DEBUG=$DEBUG go run main.go
+DEBUG=$DEBUG go run main.go

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go clean -testcache && go test ./...

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -10,6 +10,8 @@ type Extractor struct {
 }
 
 type RunParams struct {
+	Organization   string
+	RepositoryName string
 }
 
 type Repository struct {
@@ -28,7 +30,7 @@ func New() *Extractor {
 func (e *Extractor) Run(p *RunParams) (*RunResult, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
-	repo, _, err := client.Repositories.Get(ctx, "graphql-go", "graphql")
+	repo, _, err := client.Repositories.Get(ctx, p.Organization, p.RepositoryName)
 	if err != nil {
 		return nil, err
 	}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -1,0 +1,46 @@
+package extractor
+
+import (
+	"github.com/google/go-github/github"
+)
+
+type Extractor struct {
+}
+
+type RunParams struct {
+}
+
+type RunResult struct {
+}
+
+func New() *Extractor {
+
+	return &Extractor{}
+}
+
+func (e *Extractor) Run() (*RunResult, error) {
+	client := github.NewClient(nil)
+	ctx := context.Background()
+	repo, _, err := client.Repositories.Get(ctx, "graphql-go", "graphql")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r := &Repository{
+		StarsCount: *repo.StargazersCount,
+	}
+
+	result := &RunResult{
+		Repository: r,
+	}
+
+	return r
+}
+
+type Repository struct {
+	StarsCount int
+}
+
+type RunResult struct {
+	Repository *Repository
+}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -1,6 +1,9 @@
 package extractor
 
 import (
+	"context"
+	"log"
+
 	"github.com/google/go-github/github"
 )
 
@@ -10,7 +13,12 @@ type Extractor struct {
 type RunParams struct {
 }
 
+type Repository struct {
+	StarsCount int
+}
+
 type RunResult struct {
+	Repository *Repository
 }
 
 func New() *Extractor {
@@ -34,13 +42,5 @@ func (e *Extractor) Run() (*RunResult, error) {
 		Repository: r,
 	}
 
-	return r
-}
-
-type Repository struct {
-	StarsCount int
-}
-
-type RunResult struct {
-	Repository *Repository
+	return result, nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -2,7 +2,6 @@ package extractor
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/go-github/github"
 )
@@ -31,7 +30,7 @@ func (e *Extractor) Run() (*RunResult, error) {
 	ctx := context.Background()
 	repo, _, err := client.Repositories.Get(ctx, "graphql-go", "graphql")
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	r := &Repository{

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/google/go-github/github"
 )
@@ -10,6 +11,7 @@ type Extractor struct {
 }
 
 type RunParams struct {
+	HTTPClient     *http.Client
 	Organization   string
 	RepositoryName string
 }
@@ -28,7 +30,7 @@ func New() *Extractor {
 }
 
 func (e *Extractor) Run(p *RunParams) (*RunResult, error) {
-	client := github.NewClient(nil)
+	client := github.NewClient(p.HTTPClient)
 	ctx := context.Background()
 	repo, _, err := client.Repositories.Get(ctx, p.Organization, p.RepositoryName)
 	if err != nil {

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -25,7 +25,6 @@ type RunResult struct {
 }
 
 func New() *Extractor {
-
 	return &Extractor{}
 }
 

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -25,7 +25,7 @@ func New() *Extractor {
 	return &Extractor{}
 }
 
-func (e *Extractor) Run() (*RunResult, error) {
+func (e *Extractor) Run(p *RunParams) (*RunResult, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
 	repo, _, err := client.Repositories.Get(ctx, "graphql-go", "graphql")

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -1,0 +1,14 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractorRun(t *testing.T) {
+	ex := &Extractor{}
+	result, err := ex.Run(&RunParams{})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -97,7 +97,7 @@ func TestExtractorRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.subTestName, func(t *testing.T) {
-			ex := &Extractor{}
+			ex := New()
 			params := RunParams{
 				HTTPClient: testClient(&testClientParams{
 					requestMethod:      tt.requestMethod,

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -1,17 +1,61 @@
 package extractor
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
 	"testing"
 
+	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
 )
 
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}
+
 func TestExtractorRun(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			resp := &http.Response{
+				Request: r,
+			}
+			if r.Method != "GET" || r.URL.String() != "https://api.github.com/repos/graphql-go/graphql" {
+				resp.StatusCode = http.StatusNotFound
+				return resp, nil
+			}
+
+			stargazersCount := int(10)
+			repo := github.Repository{
+				StargazersCount: &stargazersCount,
+			}
+			d, err := json.Marshal(repo)
+			if err != nil {
+				log.Printf("failed to do json marshal: %v", err)
+				resp.StatusCode = http.StatusInternalServerError
+				return resp, nil
+			}
+
+			body := bytes.NewReader(d)
+			return &http.Response{
+				Body:       io.NopCloser(body),
+				Request:    r,
+				StatusCode: 200,
+			}, nil
+		}),
+	}
+
 	ex := &Extractor{}
 	params := RunParams{
+		HTTPClient:     httpClient,
 		Organization:   "graphql-go",
 		RepositoryName: "graphql",
 	}
+
 	result, err := ex.Run(&params)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -3,8 +3,8 @@ package extractor
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
-	"log"
 	"net/http"
 	"testing"
 
@@ -18,45 +18,105 @@ func (fn RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return fn(r)
 }
 
-func TestExtractorRun(t *testing.T) {
-	httpClient := &http.Client{
+type testClientParams struct {
+	requestMethod      string
+	requestURL         string
+	responseBody       func() ([]byte, error)
+	responseStatusCode int
+}
+
+func testClient(p *testClientParams) *http.Client {
+	httpClient := http.Client{
 		Transport: RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			resp := &http.Response{
-				Request: r,
+				Request:    r,
+				StatusCode: p.responseStatusCode,
 			}
-			if r.Method != "GET" || r.URL.String() != "https://api.github.com/repos/graphql-go/graphql" {
-				resp.StatusCode = http.StatusNotFound
+
+			if r.Method != p.requestMethod || r.URL.String() != p.requestURL {
 				return resp, nil
 			}
 
-			stargazersCount := int(10)
-			repo := github.Repository{
-				StargazersCount: &stargazersCount,
-			}
-			d, err := json.Marshal(repo)
+			data, err := p.responseBody()
 			if err != nil {
-				log.Printf("failed to do json marshal: %v", err)
-				resp.StatusCode = http.StatusInternalServerError
 				return resp, nil
 			}
 
-			body := bytes.NewReader(d)
+			body := bytes.NewReader(data)
 			return &http.Response{
 				Body:       io.NopCloser(body),
 				Request:    r,
-				StatusCode: 200,
+				StatusCode: p.responseStatusCode,
 			}, nil
 		}),
 	}
 
-	ex := &Extractor{}
-	params := RunParams{
-		HTTPClient:     httpClient,
-		Organization:   "graphql-go",
-		RepositoryName: "graphql",
+	return &httpClient
+}
+
+func TestExtractorRun(t *testing.T) {
+	tests := []struct {
+		subTestName        string
+		requestMethod      string
+		requestURL         string
+		responseBody       func() ([]byte, error)
+		responseStatusCode int
+		expectedError      error
+	}{
+		{
+			subTestName:   "Success",
+			requestMethod: "GET",
+			requestURL:    "https://api.github.com/repos/graphql-go/graphql",
+			responseBody: func() ([]byte, error) {
+				stargazersCount := int(8)
+				repo := github.Repository{
+					StargazersCount: &stargazersCount,
+				}
+
+				data, err := json.Marshal(repo)
+				if err != nil {
+					return nil, err
+				}
+
+				return data, nil
+			},
+			responseStatusCode: http.StatusOK,
+			expectedError:      nil,
+		},
+		{
+			subTestName:   "Handles client repositories get response error",
+			requestMethod: "test invalid get method",
+			requestURL:    "test invalid url",
+			responseBody: func() ([]byte, error) {
+				return nil, nil
+			},
+			responseStatusCode: http.StatusInternalServerError,
+			expectedError:      errors.New("GET https://api.github.com/repos/graphql-go/graphql: 500  []"),
+		},
 	}
 
-	result, err := ex.Run(&params)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
+	for _, tt := range tests {
+		t.Run(tt.subTestName, func(t *testing.T) {
+			ex := &Extractor{}
+			params := RunParams{
+				HTTPClient: testClient(&testClientParams{
+					requestMethod:      tt.requestMethod,
+					requestURL:         tt.requestURL,
+					responseBody:       tt.responseBody,
+					responseStatusCode: tt.responseStatusCode,
+				}),
+				Organization:   "graphql-go",
+				RepositoryName: "graphql",
+			}
+
+			result, err := ex.Run(&params)
+			if err != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+				return
+			}
+
+			assert.NotNil(t, result)
+		})
+	}
+
 }

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -8,7 +8,11 @@ import (
 
 func TestExtractorRun(t *testing.T) {
 	ex := &Extractor{}
-	result, err := ex.Run(&RunParams{})
+	params := RunParams{
+		Organization:   "graphql-go",
+		RepositoryName: "graphql",
+	}
+	result, err := ex.Run(&params)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/graphql-go/compatibility-user-acceptance
 
 go 1.24.1
 
-require github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e
+require (
+	github.com/google/go-github v17.0.0+incompatible
+	github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e
+)
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,10 @@ require (
 	github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e
 )
 
-require github.com/google/go-querystring v1.1.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/graphql-go/compatibility-user-acceptance
 
 go 1.24.1
+
+require github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e h1:3ASLD7OWNT+XyMwhwJwB5rN3tG6DWkQ2VO8yw8+FcdU=
+github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e/go.mod h1:/l6LBrxd74qbZuhwYB+eNRduuT6cQzyBbSYA8UtI0sI=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -6,4 +8,11 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e h1:3ASLD7OWNT+XyMwhwJwB5rN3tG6DWkQ2VO8yw8+FcdU=
 github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e/go.mod h1:/l6LBrxd74qbZuhwYB+eNRduuT6cQzyBbSYA8UtI0sI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,9 @@
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e h1:3ASLD7OWNT+XyMwhwJwB5rN3tG6DWkQ2VO8yw8+FcdU=
 github.com/graphql-go/compatibility-base v0.0.0-20250402212805-5253a07ce02e/go.mod h1:/l6LBrxd74qbZuhwYB+eNRduuT6cQzyBbSYA8UtI0sI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/graphql-go/compatibility-base/config"
 	"github.com/graphql-go/compatibility-user-acceptance/extractor"
@@ -13,6 +14,7 @@ func main() {
 
 	ex := extractor.Extractor{}
 	params := extractor.RunParams{
+		HTTPClient:     &http.Client{},
 		Organization:   "graphql-go",
 		RepositoryName: "graphql",
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,11 @@ func main() {
 	cfg := config.Config{}
 
 	ex := extractor.Extractor{}
-	r, err := ex.Run(&extractor.RunParams{})
+	params := extractor.RunParams{
+		Organization:   "graphql-go",
+		RepositoryName: "graphql",
+	}
+	r, err := ex.Run(&params)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 	cfg := config.Config{}
 
 	ex := extractor.Extractor{}
-	r, err := ex.Run()
+	r, err := ex.Run(&extractor.RunParams{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	cfg := config.Config{}
 
-	ex := extractor.Extractor{}
+	ex := extractor.New()
 	params := extractor.RunParams{
 		HTTPClient:     &http.Client{},
 		Organization:   "graphql-go",

--- a/main.go
+++ b/main.go
@@ -2,12 +2,21 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/graphql-go/compatibility-base/config"
+	"github.com/graphql-go/compatibility-user-acceptance/extractor"
 )
 
 func main() {
 	cfg := config.Config{}
 
+	ex := extractor.Extractor{}
+	r, err := ex.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Println(cfg.IsDebug)
+	fmt.Printf("%+v\n", r)
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/graphql-go/compatibility-base/config"
+)
 
 func main() {
-	fmt.Println("ok")
+	cfg := config.Config{}
+
+	fmt.Println(cfg.IsDebug)
 }


### PR DESCRIPTION
#### Details
- `{extractor,main}`: use extractor New method.
- `extractor`: adds Extractor.Run unit tests.
- `main`: wires extractor RunParams http client.
- `extractor`: wires testing http client.
- `extractor`: adds RunParams.HTTPClient field.
- `main`: wires RunParams fields.
- `extractor`: syncs unit tests.
- `extractor`: adds RunParams fields.
- `bin`: adds go test coverage script.
- `.gitignore`: adds coverage files.
- `extractor`: adds Extractor unit tests.
- `bin`: adds test script.
- `{go.mod,go.sum}`: adds github.com/stretchr/testify pkg.
- `{extractor,main}`: wires RunParams struct.
- `extractor`: improves error handling.
- `bin`: removes unused GITHUB_AUTH_TOKEN env variable.
- `main`: wires extractor component.
- `extractor`: consolidates extractor file format.
- `extractor`: adds initial extractor component implementation.
- `{go.mod,go.sum}`: adds github.com/google/go-github pkg.
- `main`: wires config component.
- `{go.mod,go.sum}`: adds github.com/graphql-go/compatibility-base pkg.

#### Test Plan
:heavy_check_mark:  Tested via `./bin/start.sh`:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-user-acceptance$ ./bin/start.sh 
false
&{Repository:0xc0002d89f8}
```

:heavy_check_mark: Tested via `./bin/test.sh`:
```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-user-acceptance$ ./bin/test.sh 
?   	github.com/graphql-go/compatibility-user-acceptance	[no test files]
ok  	github.com/graphql-go/compatibility-user-acceptance/extractor	0.003s

```